### PR TITLE
Add darker background to restaurant items #387

### DIFF
--- a/Android/app/src/main/res/layout/restaurants_card_view.xml
+++ b/Android/app/src/main/res/layout/restaurants_card_view.xml
@@ -30,6 +30,11 @@
                 android:layout_marginStart="11dp"
                 android:textSize="12sp" />
 
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/transparent_black">
+
             <ImageView
                 android:id="@+id/image"
                 android:layout_width="fill_parent"
@@ -87,6 +92,8 @@
                 android:textColor="@android:color/white"
                 android:textSize="14sp"
                 android:textStyle="bold" />
+
+            </RelativeLayout>
 
             <TextView
                 android:id="@+id/votes"

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="silver">#969696</color>
     <color name="blue">#0288D1</color>
     <color name="dark_grey">#333434</color>
+    <color name="transparent_black">#CC000000</color>
 
 
     <color name="saffron">#F4B63E</color>


### PR DESCRIPTION

<img width="246" alt="screen shot 2018-10-03 at 12 43 03 am" src="https://user-images.githubusercontent.com/24760136/46363352-5a331200-c6a5-11e8-8168-b04984363ce6.png">

UI change #387, the background change to dark similar to utilities or travel cards

Fixes #387

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings